### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Example rust iron webapp with react and webpack
 
+## Nitrous Quickstart
+
+Create a free development environment for this example webapp project in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking the button below.
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start this example webapp via `Run > Start Rust Iron React Webpack` and access your site via `Preview > 3000`.
+
 ## Building
 
  1. clone this repo

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Rust + Iron + React + Webpack example project on Nitrous.
+
+## Running the server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start this example project via "Run > Start Rust Iron React Webpack"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "rust",
+  "ports": [3000, 8080],
+  "name": "Example rust iron webapp with react and webpack",
+  "description": "Example webapp using Rust + Iron + React + Webpack",
+  "scripts": {
+    "post-create": "cargo build && cd web && sed -i 's/localhost/0.0.0.0/g' server.js && echo 'running npm install - this might take awhile...' && npm install",
+    "Start Rust Iron React Webpack": "cd ~/code/rust-iron-react-webpack && cargo run & cd web && npm start"
+  }
+}

--- a/web/webpack.dev.config.js
+++ b/web/webpack.dev.config.js
@@ -13,7 +13,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
-    publicPath: 'http://localhost:3000/'
+    publicPath: '/'
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.
